### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/pricklypear.yaml
+++ b/pricklypear.yaml
@@ -1,10 +1,3 @@
 enabled: true
 dropdown:
   enabled: false
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/pricklypear


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
